### PR TITLE
Avoid race at `Close()` time

### DIFF
--- a/reader_test.go
+++ b/reader_test.go
@@ -528,9 +528,9 @@ func TestSyncReaderPubSubHappyPath(t *testing.T) {
 		ctx:   context.Background(),
 		delay: time.Duration(100) * time.Millisecond,
 		contents: []interface{}{
-			redis.Subscription{},
+			redis.PMessage{},
 			redis.Message{},
-			redis.Subscription{},
+			redis.PMessage{},
 			redis.Message{},
 		},
 	}


### PR DESCRIPTION
fixes #3 

If you just `Close()` a `PubSubConn` raw, it internally runs a `Receive(...)` method which races against the `Receive(...)` in `pubSubStimulus(...)`, and you end up deadlocked.

So, to be conscientious when closing down, unsubscribe from everything, and have the go routine shut itself down when there are no subscriptions left.

Our `Close()` is getting a bit busy... So maybe a cleanup is called for in the near future?